### PR TITLE
cloudpickle: Update from 1.6.0 to 2.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
-  build:
+  host:
     - python >=3.6
     - pip
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,8 @@ requirements:
   build:
     - python >=3.6
     - pip
+    - setuptools
+    - wheel
 
   run:
     - python >=3.6
@@ -25,6 +27,10 @@ requirements:
 test:
   imports:
     - cloudpickle
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/cloudpipe/cloudpickle

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.6.0" %}
+{% set version = "2.0.0" %}
 
 package:
   name: cloudpickle
@@ -7,7 +7,7 @@ package:
 source:
   fn: cloudpickle-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/c/cloudpickle/cloudpickle-{{ version }}.tar.gz
-  sha256: 9bc994f9e9447593bd0a45371f0e7ac7333710fcf64a4eb9834bf149f4ef2f32
+  sha256: 5cd02f3b417a783ba84a4ec3e290ff7929009fe51f6405423cfccfadd43ba4a4
 
 build:
   number: 0
@@ -15,12 +15,12 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
-  host:
-    - python >=3.5
+  build:
+    - python >=3.6
     - pip
 
   run:
-    - python >=3.5
+    - python >=3.6
 
 test:
   imports:


### PR DESCRIPTION
* [x] upstream repo https://github.com/cloudpipe/cloudpickle
* [x] run tests on dependent packages
```
cloudpickle-feedstock/recipe/meta.yaml:    - cloudpickle
dask-core-feedstock/recipe/meta.yaml:    - cloudpickle >=1.1.1
distributed-feedstock/recipe/meta.yaml:    - cloudpickle >=1.5.0
doit-feedstock/recipe/meta.yaml:    - cloudpickle
pygmo-feedstock/recipe/meta.yaml:    - cloudpickle
pygmo-feedstock/recipe/meta.yaml:    - cloudpickle
scikit-image-feedstock/recipe/meta.yaml:    - cloudpickle >=0.2.1
spyder-feedstock/recipe/meta.yaml:    - cloudpickle >=0.5.0
spyder-kernels-0.2.4-feedstock/recipe/meta.yaml:    - cloudpickle
spyder-kernels-0.x-feedstock/recipe/meta.yaml:    - cloudpickle
spyder-kernels-feedstock/recipe/meta.yaml:    - cloudpickle
tabpy-client-feedstock/recipe/meta.yaml:    - cloudpickle
tabpy-server-feedstock/recipe/meta.yaml:    - cloudpickle
tensorflow-probability-feedstock/recipe/meta.yaml:    - cloudpickle =1.1.1
```
  * Built doit using new cloudpickle
* [x] go through [changelog](https://github.com/cloudpipe/cloudpickle/blob/master/CHANGES.md)
  * Python 3.5 is no longer supported.
* [x] look for any open issues for new versions
* [x] dev_url, doc_url valid
* [x] setuptools/wheel/pip/pip check included
* [x] compare pinned versions from upstream github setup
```
meta.yaml
    - python >=3.6

setup.py
        'Programming Language :: Python :: 3.6',
        'Programming Language :: Python :: 3.7',
        'Programming Language :: Python :: 3.8',
        'Programming Language :: Python :: 3.9',

tox.ini
envlist = py35, py36, py37, py38, py39, pypy3
```
