### PR TITLE
Update to 2.2.1 to support Python 3.11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.0.0" %}
+{% set version = "2.2.1" %}
 
 package:
   name: cloudpickle
@@ -7,22 +7,23 @@ package:
 source:
   fn: cloudpickle-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/c/cloudpickle/cloudpickle-{{ version }}.tar.gz
-  sha256: 5cd02f3b417a783ba84a4ec3e290ff7929009fe51f6405423cfccfadd43ba4a4
+  sha256: d89684b8de9e34a2a43b3460fbca07d09d6e25ce858df4d5a44240403b6178f5
 
 build:
   number: 0
+  skip: true # [py<36]
   noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
     - setuptools
     - wheel
 
   run:
-    - python >=3.6
+    - python
 
 test:
   imports:
@@ -35,13 +36,13 @@ test:
 about:
   home: https://github.com/cloudpipe/cloudpickle
   license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE
   summary: Extended pickling support for Python objects
   description: |
     cloudpickle is extended pickling support for Python objects.
     cloudpickle makes it possible to serialize Python constructs not
     supported by the default pickle module from the Python standard library.
-  doc_url: https://pypi.python.org/pypi/cloudpickle/{{ version }}
   doc_source_url: https://github.com/cloudpipe/cloudpickle/blob/master/README.md
   dev_url: https://github.com/cloudpipe/cloudpickle
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
 build:
   number: 0
   skip: true # [py<36]
-  noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
 
 requirements:


### PR DESCRIPTION
Note that technically, support for Python 3.11 was added in 2.1.0.

This is required for https://github.com/AnacondaRecipes/modin-feedstock/pull/10 (and `distributed` too that was recently updated).

Upstream diff: https://github.com/cloudpipe/cloudpickle/compare/v2.0.0..v2.2.1