### PR TITLE
Update 3.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
+{% set name = "cloudpickle" %}
 {% set version = "3.0.0" %}
 
 package:
-  name: cloudpickle
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: cloudpickle-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/c/cloudpickle/cloudpickle-{{ version }}.tar.gz
-  sha256: 996d9a482c6fb4f33c1a35335cf8afd065d2a56e973270364840712d9131a882
+  url: https://github.com/cloudpipe/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 49cc8581ce305630b1e179bc083069b21b45db4731e5e3f2ea6fc40b131e1c55
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   skip: true # [py<38]
-  script:  {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
+  script:  {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -v
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ about:
   home: https://github.com/cloudpipe/cloudpickle
   license: BSD-3-Clause
   license_family: BSD
-  license_file: LICENSE
+  # license_file: ../LICENSE
   summary: Extended pickling support for Python objects
   description: |
     cloudpickle is extended pickling support for Python objects.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,6 @@ requirements:
   run:
     - python
 
-
 test:
   imports:
     - cloudpickle

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.2.1" %}
+{% set version = "3.0.0" %}
 
 package:
   name: cloudpickle
@@ -7,12 +7,12 @@ package:
 source:
   fn: cloudpickle-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/c/cloudpickle/cloudpickle-{{ version }}.tar.gz
-  sha256: d89684b8de9e34a2a43b3460fbca07d09d6e25ce858df4d5a44240403b6178f5
+  sha256: 996d9a482c6fb4f33c1a35335cf8afd065d2a56e973270364840712d9131a882
 
 build:
   number: 0
-  skip: true # [py<36]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
+  skip: true # [py<38]
+  script:  {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   host:
@@ -23,6 +23,7 @@ requirements:
 
   run:
     - python
+    - flit-core
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ about:
   home: https://github.com/cloudpipe/cloudpickle
   license: BSD-3-Clause
   license_family: BSD
-  # license_file: ../LICENSE
+  license_file: LICENSE
   summary: Extended pickling support for Python objects
   description: |
     cloudpickle is extended pickling support for Python objects.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,12 +18,11 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
-    - wheel
+    - flit-core
 
   run:
     - python
-    - flit-core
+
 
 test:
   imports:


### PR DESCRIPTION
## ☆Cloudpickle 3.0.0 Update ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-5238)
[Upstream](https://github.com/cloudpipe/cloudpickle)
# Changes
- Updated version number and `sha256`
- To properly reference licensing files, the PyPI source URL has been updated  to `cloudpickle’s` upstream github url
- Added new dependency to `host`